### PR TITLE
Prevent NPE on list of null type

### DIFF
--- a/src/groovy/com/cscinfo/platform/constraint/CascadeValidationConstraint.groovy
+++ b/src/groovy/com/cscinfo/platform/constraint/CascadeValidationConstraint.groovy
@@ -36,6 +36,10 @@ class CascadeValidationConstraint extends AbstractVetoingConstraint {
     }
 
     private boolean validateValue(target, value, errors, index = null) {
+        if (value == null) {
+            return true
+        }
+
         if (!value.respondsTo('validate')) {
             throw new NoSuchMethodException("Error validating field [${constraintPropertyName}]. Unable to apply 'cascade' constraint on [${value.class}] because the object does not have a validate() method. If the object is a command object, you may need to add the @Validateable annotation to the class definition.")
         }


### PR DESCRIPTION
I don't know if this branch is still maintained, but decided to give it a try. Also sorry for not adding any tests.

Previous to this patch, the following code throws NPE when mydata = [ null ]:
```
List<MyDataType> mydata
static constraints = { mydata(nullable: true, cascade: true) }
```
